### PR TITLE
Reorder dockerfile instructions for better caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 **/.dockerignore
 **/.env
 **/.git
+**/.github
 **/.gitignore
 **/.project
 **/.settings
@@ -12,13 +13,18 @@
 **/*.dbmdl
 **/*.jfm
 **/charts
+**/deployment
 **/docker-compose*
 **/compose*
 **/Dockerfile*
+**/integration
 **/node_modules
 **/npm-debug.log
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
 **/dist
+*.sh
+local.env
+LICENSE
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM node:16-alpine3.15 as build
 
 WORKDIR /home/user/build
 
+RUN npm install typescript@4.6.4
 COPY . .
-RUN npm install typescript
 RUN node_modules/.bin/tsc
 
 FROM zenika/alpine-chrome:101-with-node-16
@@ -14,9 +14,9 @@ ENV PUPPETEER_EXECUTABLE_PATH /usr/bin/chromium-browser
 WORKDIR /app
 USER root
 
-COPY --from=build /home/user/build/dist/ ./dist/
 COPY package.json package-lock.json ./
 RUN npm install -g npm@8.10.0 && npm install
+COPY --from=build /home/user/build/dist/ ./dist/
 RUN chown -R chrome /app/
 
 USER chrome

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM node:16-alpine3.15 as build
 
 WORKDIR /home/user/build
 
-RUN npm install typescript@4.6.4
+RUN npm install -g typescript@4.6.4
 COPY . .
-RUN node_modules/.bin/tsc
+RUN tsc
 
 FROM zenika/alpine-chrome:101-with-node-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM node:16-alpine3.15 as build
 
 WORKDIR /home/user/build
 
-RUN npm install -g typescript@4.6.4
+RUN npm install -g typescript@4.6.4 npm@8.10.0
 COPY . .
-RUN tsc
+RUN npm install && tsc
 
 FROM zenika/alpine-chrome:101-with-node-16
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^27.5.1",
     "@types/node": "^17.0.33",
     "jest": "^28.1.0",
-    "typescript": "^4.6.4"
+    "typescript": "4.6.4"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
Typescript installation in build container can be cached.
npm installation in run container can be cached.