### PR TITLE
Destroy clients after each integration test

### DIFF
--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -42,6 +42,11 @@ describe('Integration tests', () => {
         await dynamoDBClient.send(putItemCommand)
     })
 
+    afterEach(async () => {
+        dynamoDBClient.destroy()
+        sqsClient.destroy()
+    })
+
     test('Send epub job and download epub', async () => {
         // given
         const message: Message = {


### PR DESCRIPTION
Maybe fixes the issue of integration tests not finishing due to an asynchronous operation
```
Jest did not exit one second after the test run has completed.
This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```
https://github.com/NovelService/NovelWorkerNode/runs/6694756460?check_suite_focus=true
